### PR TITLE
Set `bash` as default shell to `solr` user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ solr_user: solr
 # solr_user_uid:
 solr_user_group: solr
 # solr_user_group_gid:
-solr_user_shell: /usr/sbin/nologin
+solr_user_shell: /bin/bash
 solr_user_home: /var/lib/solr
 # solr_user_create_home: true
 


### PR DESCRIPTION
This is needed to allow using rsync over SSH whose access is restricted by not having set any password and setting an authorized key with the exact command rrsync through the repository `metabrainz-ansible`.

Reference:
https://github.com/metabrainz/metabrainz-ansible/commit/6d274d4d6448610dc4142ccf1394757653e277ec#diff-f6c2dc6aa40eae95a6282f4def83e9a290373d083be7d52d2dac1898e1acc344R29-R30