### PR TITLE
Use as many Solr search threads as CPU threads

### DIFF
--- a/files/var/lib/solr/solr.xml
+++ b/files/var/lib/solr/solr.xml
@@ -34,6 +34,7 @@
   <str name="allowPaths">${solr.allowPaths:}</str>
   <str name="allowUrls">${solr.allowUrls:}</str>
   <str name="hideStackTrace">${solr.hideStackTrace:false}</str>
+  <int name="indexSearcherExecutorThreads">${solr.indexSearcherExecutorThreads:-1}</int>
 
   <solrcloud>
 


### PR DESCRIPTION
A “new/experimental multiThreaded=true parameter” has been “introduced in 9.7”. Even though `indexSearcherExecutorThreads = -1` is documented in 9.8.1 changes, it seems according to @zas that setting it does affect 9.7 in a good way already.

References:
- https://solr.apache.org/guide/solr/9_8/upgrade-notes/major-changes-in-solr-9.html#solr-9-8
- https://solr.apache.org/guide/solr/9_8/upgrade-notes/major-changes-in-solr-9.html#solr-9-8-1
- https://github.com/metabrainz/metabrainz-ansible/pull/75#issuecomment-2908707527
- https://github.com/metabrainz/metabrainz-ansible/pull/75#issuecomment-2909214816